### PR TITLE
Updated to later dependencies for Koa and Hapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ yarn add koa2-joi-validate joi
 ## Usage
 
 ```js
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const Koa = require('koa');
 const app = new Koa();
-const Router = require('koa-router');
+const Router = require('@koa/router');
 
 const validator = require('koa2-joi-validate')();
 const querySchema = Joi.object({
@@ -163,7 +163,7 @@ const validator = require('koa2-joi-validate')({
 const Koa = require('koa');
 const app = new Koa();
 
-const Router = require('koa-router');
+const Router = require('@koa/router');
 const router = new Router();
 
 // Before your routes add a standard Koa2 error handler. This will be passed the Joi

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function buildErrorString(err, container) {
 module.exports = function generateJoiMiddlewareInstance(cfg) {
   cfg = cfg || {}; // default to an empty config
 
-  const Joi = cfg.joi || require('joi');
+  const Joi = cfg.joi || require('@hapi/joi');
 
   const instance = { };
 

--- a/index.test.js
+++ b/index.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const sinon = require('sinon')
 const supertest = require('supertest')
 const expect = require('chai').expect
@@ -12,7 +12,7 @@ describe('Koa2 JOI TEST', function() {
   const bodyParser = require('koa-bodyparser');
   app.use(bodyParser());
 
-  const Router = require('koa-router');
+  const Router = require('@koa/router');
   const router = new Router();
 
   const server = app.listen(3000);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha *.test.js"
   },
   "engines": {
-    "node": ">=7.0.0"
+    "node": ">=8.0.0"
   },
   "keywords": [
     "joi",
@@ -35,18 +35,18 @@
   },
   "homepage": "https://github.com/Dunnodv/koa2-joi-validate#readme",
   "peerDependencies": {
-    "joi": "*"
+    "@hapi/joi": "*"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "clear-require": "^3.0.0",
-    "joi": "^10.6.0",
-    "koa": "^2.6.2",
+    "@hapi/joi": "^15.1.1",
+    "koa": "^2.11.0",
     "koa-bodyparser": "^4.2.1",
-    "koa-router": "^7.4.0",
-    "mocha": "^5.2.0",
-    "sinon": "^7.2.2",
+    "@koa/router": "^8.0.5",
+    "mocha": "^6.2.2",
+    "sinon": "^8.0.2",
     "supertest": "^3.3.0",
-    "tape": "^4.9.1"
+    "tape": "^4.12.1"
   }
 }


### PR DESCRIPTION
Koa and Hapi projects are both now contained under namespaces.  The dependencies in this project had gotten stale, but the code still works fine.